### PR TITLE
Relax hardware labelling to include dash and underscore

### DIFF
--- a/lib/aquilon/aqdb/model/hardware_entity.py
+++ b/lib/aquilon/aqdb/model/hardware_entity.py
@@ -75,7 +75,7 @@ class HardwareEntity(Base):
                       {'info': {'unique_fields': ['label']}},)
     __mapper_args__ = {'polymorphic_on': hardware_type}
 
-    _label_check = re.compile("^[a-z][a-z0-9]{,62}$")
+    _label_check = re.compile(r"^[a-z][a-z0-9\-_]{,62}$")
 
     @classmethod
     def check_label(cls, label):


### PR DESCRIPTION
Our naming scheme for network devices (switches, routers) uses dashes and underscores to separate fields.

Change-Id: I0d42aa3469b0b515fb8377911ab9e07f5511b4f2