### PR TITLE
Allow an additional decimal at the end of an interface name

### DIFF
--- a/lib/aquilon/aqdb/model/interface.py
+++ b/lib/aquilon/aqdb/model/interface.py
@@ -249,7 +249,7 @@ class PublicInterface(Interface):
 
     extra_fields = ['bootable', 'port_group_name', 'port_group']
 
-    name_check = re.compile(r"^[a-z]+\d+[a-z]?$")
+    name_check = re.compile(r"^[a-z]+\d+[a-z]?\d?$")
 
     model_allowed = True
 


### PR DESCRIPTION
For instance: p1p0

Arguably this level of checking no longer makes sense given that Linux will accept almost anything as a device name now.

Change-Id: Icf31efbfd6c89ba2616ea083dfff52a727e73a4d