### PR TITLE
Do not change the permissions of an existing sockdir

### DIFF
--- a/lib/twisted/plugins/aqd.py
+++ b/lib/twisted/plugins/aqd.py
@@ -176,7 +176,6 @@ class AQDMaker(object):
         sockdir = config.get("broker", "sockdir")
         if not os.path.exists(sockdir):
             os.makedirs(sockdir, 0o700)
-        os.chmod(sockdir, 0o700)
 
         if options["usesock"]:
             return strports.service("unix:%s/aqdsock" % sockdir, openSite)


### PR DESCRIPTION
We use this to allow apache cgi scripts to communicate with aqd via the knc socket.

Change-Id: I065cd3b4b766f7e1d726e0e2adcfcf3e4ac0c03e

There is an argument for making this configurable.