### PR TITLE
Add support for aq search_host --feature

### DIFF
--- a/etc/input.xml
+++ b/etc/input.xml
@@ -470,6 +470,7 @@
 	    <option name="mac" type="mac">[Deprecated] MAC address</option>
 	    <option name="personality" type="string">Personality</option>
 	    <option name="personality_stage" requires="personality" type="string">Personality stage</option>
+	    <option name="feature" type="string">Feature</option>
 	    <option name="host_environment" type="string">Host environment</option>
 	    <option name="osname" type="string">OS name</option>
 	    <option name="osversion" type="string">OS version</option>

--- a/lib/aquilon/worker/commands/search_host.py
+++ b/lib/aquilon/worker/commands/search_host.py
@@ -29,7 +29,8 @@ from aquilon.aqdb.model import (Host, Cluster, Archetype, Personality,
                                 Fqdn, DnsDomain, Interface, AddressAssignment,
                                 NetworkEnvironment, Network, MetaCluster,
                                 VirtualMachine, ClusterResource, HardwareEntity,
-                                HostEnvironment, User, Branch)
+                                HostEnvironment, User, Branch,
+                                Feature, FeatureLink)
 from aquilon.aqdb.model.dns_domain import parse_fqdn
 from aquilon.worker.broker import BrokerCommand
 from aquilon.worker.formats.list import StringAttributeList
@@ -52,7 +53,7 @@ class CommandSearchHost(BrokerCommand):
                sandbox, branch, sandbox_author, dns_domain, shortname, mac, ip,
                networkip, network_environment, exact_location, metacluster,
                server_of_service, server_of_instance, grn, eon_id, fullinfo,
-               orphaned, style, **arguments):
+               orphaned, style, feature, **arguments):
         dbnet_env = NetworkEnvironment.get_unique_or_default(session,
                                                              network_environment)
 
@@ -200,6 +201,11 @@ class CommandSearchHost(BrokerCommand):
                                                               host_environment)
                     q = q.filter_by(host_environment=dbhost_env)
 
+            q = q.reset_joinpoint()
+
+        if feature:
+            q = q.join(Personality).join(FeatureLink).join(Feature)
+            q = q.filter_by(name=feature)
             q = q.reset_joinpoint()
 
         if buildstatus:


### PR DESCRIPTION
At RAL we rigorously enforce the independence of features and keep shared code
separate from the features tree. This allows us to rely on the broker's view of
which features are used by particular personalities and hosts.

Change-Id: I6056fbb83ec1b22636844e662a34f635bac1254b

This may be another candidate for something that requires a configuration option to enable.