### PR TITLE
Create usable EL7 rpms with bdist_rpm that pull in all dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,23 +1,27 @@
 [bdist_rpm]
-requires = python-zope-interface
-           python-coverage
-           ipaddress
-           ipython >= 3.1.0, ipython < 4.0.0
-           python-twisted-core >= 12.2.0
-           aquilon-protocols
-           PyYAML
-           python-lxml
-           python-dateutil
-           python-sqlalchemy >= 0.9.7
+requires = ant-apache-regexp
            ant-contrib
-           krb5-workstation
-           python-twisted-runner >= 12.2.0
-           python-mako
+           aquilon-protocols
+           python-ipaddress
+           ipython >= 3.1.0, ipython < 4.0.0
            knc >= 1.7.1
-           ant-apache-regexp
-build_requires = python-cheetah
-                 docbook5-style-xsl
+           krb5-workstation
+           python-coverage
+           python-dateutil
+           python-lxml
+           python-mako
+           python-psycopg2 >= 2.5.1
+           python-six >= 1.7.3
+           python-sqlalchemy >= 0.9.7
+           python-twisted-core >= 12.2.0
+           python-twisted-runner >= 12.2.0
+           python-twisted-web >= 12.2.0
+           python-zope-interface
+           PyYAML
+build_requires =
                  docbook5-schemas
+                 docbook5-style-xsl
+                 python-cheetah
                  system-release
 release = 1%{dist}
 group = quattor

--- a/tools/cleanup-ms.sh
+++ b/tools/cleanup-ms.sh
@@ -17,7 +17,6 @@ grep -lrE '(import aquilon.*depends)|(from aquilon.*import depends)' . \
     |xargs sed -i '/\(import aquilon.*depends\)\|\(from aquilon.*import depends\)/d'
 stylesheets=/usr/share/sgml/docbook/xsl-ns-stylesheets-$(rpm -q --qf %{VERSION} \
     docbook5-style-xsl)
-sed -i '/ms.version/d' tools/gen_completion.py
 sed -i -e "s:^XSLTPROC =.*:XSLTPROC = xsltproc" \
 	-e "s:^XMLLINT =.*:XMLLINT = xmllint" \
 	-e "s:^DOCBOOK_XSL =.*:DOCBOOK_XSL = $stylesheets" \


### PR DESCRIPTION
cleanup-ms: tools/gen_completion already handles missing ms.version, removing it creates invalid code
setup.cfg: sort requires and build_requires
setup.cfg: ipaddress is provided by python-ipaddress rpm
setypcfg: add recent dependencies for python six,psycopg2,twisted-web (all available on EL7/EPEL7)

Change-Id: Ic555c34f60c94b3fe3ff20c9468e5cd2ecb25152

Replaces #41 and #58 
Fixes #47 and #48