### PR TITLE
Add aquilon-broker unit file for systemd

### DIFF
--- a/etc/systemd/aquilon-broker.service
+++ b/etc/systemd/aquilon-broker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Quattor Aquilon broker
+After=network.target
+
+[Service]
+# /etc/sysconfig/aqd must be created from the default file provided with Aquilon (see the documentation)
+EnvironmentFile=/etc/sysconfig/aqd
+# Update python path to reflect your configuration. If a virtualenv is used, be sure to use the python path
+# for the virutalenv
+ExecStart=/usr/bin/python ${TWISTD} --logfile=${LOGFILE} --pidfile=${PIDFILE} aqd --config=${CONF_FILE}"
+Restart=always
+SyslogIdentifier=aqd
+User=aquilon
+Group=aquilon
+Type=forking
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR allows to manage aquilon broker with systemd rather than through the initd emulation. This gives more flexibility, in particular when the broker is run using a Python virtualenv.