### PR TITLE
Plenary template adjustment to fix the template library support

### DIFF
--- a/etc/aqd.conf.defaults
+++ b/etc/aqd.conf.defaults
@@ -346,6 +346,7 @@ gzip_output = false
 # only used if gzip_output = true
 transparent_gzip = true
 template_extension = .tpl
+object_declarations_template = false
 
 [tool_timeout]
 # If set to True, timeout will be set to 'default_value' for any tools run via subprocess

--- a/etc/aqd.conf.defaults
+++ b/etc/aqd.conf.defaults
@@ -346,7 +346,6 @@ gzip_output = false
 # only used if gzip_output = true
 transparent_gzip = true
 template_extension = .tpl
-include_pan = True
 
 [tool_timeout]
 # If set to True, timeout will be set to 'default_value' for any tools run via subprocess

--- a/etc/aqd.conf.noms
+++ b/etc/aqd.conf.noms
@@ -84,6 +84,10 @@ location_uri_validator = /bin/true
 # in raw mode and set the version variable itself.
 pan_compiler = /usr/lib/panc.jar
 
+# Include a preface template in the object template if true
+object_declarations_template = true
+
+
 ###############################################################################
 
 [site]

--- a/lib/aquilon/worker/templates/cluster.py
+++ b/lib/aquilon/worker/templates/cluster.py
@@ -188,12 +188,7 @@ class PlenaryClusterObject(ObjectPlenary):
         return CompileKey.merge(keylist)
 
     def body(self, lines):
-        # This is required to be able to override LOADPATH
-        if self.config.getboolean("panc", "include_pan"):
-            pan_include(lines, ["pan/units", "pan/functions"])
-            lines.append("")
-
-        # Okay, here's the real content
+        pan_include(lines, ["pan/units", "pan/functions"])
         path = PlenaryClusterData.template_name(self.dbobj)
         pan_assign(lines, "/",
                    StructureTemplate(path,

--- a/lib/aquilon/worker/templates/cluster.py
+++ b/lib/aquilon/worker/templates/cluster.py
@@ -188,7 +188,17 @@ class PlenaryClusterObject(ObjectPlenary):
         return CompileKey.merge(keylist)
 
     def body(self, lines):
+        # Allow settings such as loadpath to be modified by the archetype before anything else happens
+        # Included only if object_declarations_template option is true
+        # It the option is true, the template MUST exist
+        if self.config.getboolean("panc", "object_declarations_template"):
+            pan_include(lines, "archetype/declarations")
+            lines.append("")
+
         pan_include(lines, ["pan/units", "pan/functions"])
+        lines.append("")
+
+        # Okay, here's the real content
         path = PlenaryClusterData.template_name(self.dbobj)
         pan_assign(lines, "/",
                    StructureTemplate(path,

--- a/lib/aquilon/worker/templates/host.py
+++ b/lib/aquilon/worker/templates/host.py
@@ -374,12 +374,10 @@ class PlenaryHostObject(ObjectPlenary):
         services.sort()
         provides.sort()
 
-        # This is required to be able to override LOADPATH
-        if self.config.getboolean("panc", "include_pan"):
-            pan_include(lines, ["pan/units", "pan/functions"])
-            lines.append("")
-
         # Okay, here's the real content
+        pan_include(lines, ["pan/units", "pan/functions"])
+        lines.append("")
+
         path = PlenaryHostData.template_name(self.dbobj)
         pan_assign(lines, "/",
                    StructureTemplate(path,

--- a/lib/aquilon/worker/templates/host.py
+++ b/lib/aquilon/worker/templates/host.py
@@ -374,10 +374,17 @@ class PlenaryHostObject(ObjectPlenary):
         services.sort()
         provides.sort()
 
-        # Okay, here's the real content
+        # Allow settings such as loadpath to be modified by the archetype before anything else happens
+        # Included only if object_declarations_template option is true
+        # It the option is true, the template MUST exist
+        if self.config.getboolean("panc", "object_declarations_template"):
+            pan_include(lines, "archetype/declarations")
+            lines.append("")
+
         pan_include(lines, ["pan/units", "pan/functions"])
         lines.append("")
 
+        # Okay, here's the real content
         path = PlenaryHostData.template_name(self.dbobj)
         pan_assign(lines, "/",
                    StructureTemplate(path,

--- a/lib/aquilon/worker/templates/machine.py
+++ b/lib/aquilon/worker/templates/machine.py
@@ -72,7 +72,7 @@ class PlenaryMachineInfo(StructurePlenary):
 
     def body(self, lines):
         ram = [StructureTemplate("hardware/ram/generic",
-                                 {"size": self.dbobj.memory})]
+                                 {"size": PanMetric(self.dbobj.memory, "MB")})]
         cpu = StructureTemplate("hardware/cpu/%s/%s" %
                                 (self.dbobj.cpu_model.vendor.name,
                                  self.dbobj.cpu_model.name))
@@ -81,7 +81,7 @@ class PlenaryMachineInfo(StructurePlenary):
         disks = {}
         for disk in self.dbobj.disks:
             devname = disk.device_name
-            params = {"capacity": PanMetric(disk.capacity, 1024),
+            params = {"capacity": PanMetric(disk.capacity, "GB"),
                       "interface": disk.controller_type}
             if disk.bootable:
                 params["boot"] = True

--- a/lib/aquilon/worker/templates/metacluster.py
+++ b/lib/aquilon/worker/templates/metacluster.py
@@ -117,7 +117,17 @@ class PlenaryMetaClusterObject(ObjectPlenary):
         return CompileKey.merge(keylist)
 
     def body(self, lines):
+        # Allow settings such as loadpath to be modified by the archetype before anything else happens
+        # Included only if object_declarations_template option is true
+        # It the option is true, the template MUST exist
+        if self.config.getboolean("panc", "object_declarations_template"):
+            pan_include(lines, "archetype/declarations")
+            lines.append("")
+
         pan_include(lines, ["pan/units", "pan/functions"])
+        lines.append("")
+
+        # Okay, here's the real content
         pan_assign(lines, "/",
                    StructureTemplate("clusterdata/%s" % self.dbobj.name,
                                      {"metadata": PanValue("/metadata")}))

--- a/lib/aquilon/worker/templates/metacluster.py
+++ b/lib/aquilon/worker/templates/metacluster.py
@@ -117,12 +117,7 @@ class PlenaryMetaClusterObject(ObjectPlenary):
         return CompileKey.merge(keylist)
 
     def body(self, lines):
-        # This is required to be able to override LOADPATH
-        if self.config.getboolean("panc", "include_pan"):
-            pan_include(lines, ["pan/units", "pan/functions"])
-            lines.append("")
-
-        # Okay, here's the real content
+        pan_include(lines, ["pan/units", "pan/functions"])
         pan_assign(lines, "/",
                    StructureTemplate("clusterdata/%s" % self.dbobj.name,
                                      {"metadata": PanValue("/metadata")}))

--- a/tests/broker/test_add_disk.py
+++ b/tests/broker/test_add_disk.py
@@ -102,14 +102,14 @@ class TestAddDisk(EventsTestMixin, TestBrokerCommand):
                           r'"harddisks/{sda}" = '
                           r'create\("hardware/harddisk/generic/scsi",\s*'
                           r'"boot", true,\s*'
-                          r'"capacity", 68\*1024,\s*'
+                          r'"capacity", 68\*GB,\s*'
                           r'"interface", "scsi"\s*\);',
                           command)
         self.searchoutput(out,
                           r'"harddisks/{sdb}" = '
                           r'create\("hardware/harddisk/generic/scsi",\s*'
                           r'"address", "0:0:1:0",\s*'
-                          r'"capacity", 34\*1024,\s*'
+                          r'"capacity", 34\*GB,\s*'
                           r'"interface", "scsi"\s*\);',
                           command)
 
@@ -130,7 +130,7 @@ class TestAddDisk(EventsTestMixin, TestBrokerCommand):
                           r'"harddisks/{cciss/c0d0}" = '
                           r'create\("hardware/harddisk/generic/cciss",\s*'
                           r'"bus", "pci:0000:01:00.0",\s*'
-                          r'"capacity", 34\*1024,\s*'
+                          r'"capacity", 34\*GB,\s*'
                           r'"interface", "cciss",\s*'
                           r'"wwn", "600508b112233445566778899aabbccd"\s*\);',
                           command)
@@ -138,7 +138,7 @@ class TestAddDisk(EventsTestMixin, TestBrokerCommand):
                           r'"harddisks/{sda}" = '
                           r'create\("hardware/harddisk/generic/scsi",\s*'
                           r'"boot", true,\s*'
-                          r'"capacity", 68\*1024,\s*'
+                          r'"capacity", 68\*GB,\s*'
                           r'"interface", "scsi"\s*\);',
                           command)
 

--- a/tests/broker/test_add_machine.py
+++ b/tests/broker/test_add_machine.py
@@ -84,7 +84,7 @@ class TestAddMachine(MachineTestMixin, TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 8192\s*\)\s*\);',
+                          r'"size", 8192\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
@@ -259,7 +259,7 @@ class TestAddMachine(MachineTestMixin, TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 8192\s*\)\s*\);',
+                          r'"size", 8192\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
@@ -297,7 +297,7 @@ class TestAddMachine(MachineTestMixin, TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 8192\s*\)\s*\);',
+                          r'"size", 8192\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
@@ -332,7 +332,7 @@ class TestAddMachine(MachineTestMixin, TestBrokerCommand):
                          'create("hardware/harddisk/generic/cciss",',
                          command)
         self.matchoutput(out,
-                         '"capacity", 466*1024',
+                         '"capacity", 466*GB',
                          command)
 
     def test_170_add_ut3c1n9(self):

--- a/tests/broker/test_add_virtual_hardware.py
+++ b/tests/broker/test_add_virtual_hardware.py
@@ -177,7 +177,7 @@ class TestAddVirtualHardware(EventsTestMixin, TestBrokerCommand):
             self.searchoutput(out,
                               r'"ram" = list\(\s*'
                               r'create\("hardware/ram/generic",\s*'
-                              r'"size", 8192\s*\)\s*\);',
+                              r'"size", 8192\*MB\s*\)\s*\);',
                               command)
             self.searchoutput(out,
                               r'"cpu" = list\(\s*'
@@ -194,7 +194,7 @@ class TestAddVirtualHardware(EventsTestMixin, TestBrokerCommand):
                               r'"harddisks/\{sda\}" = nlist\(\s*'
                               r'"address", "0:0",\s*'
                               r'"boot", true,\s*'
-                              r'"capacity", 15\*1024,\s*'
+                              r'"capacity", 15\*GB,\s*'
                               r'"interface", "sata",\s*'
                               r'"mountpoint", "/vol/lnn30f1v1/test_share_%d",\s*'
                               r'"path", "evm%d/sda.vmdk",\s*'
@@ -467,7 +467,7 @@ class TestAddVirtualHardware(EventsTestMixin, TestBrokerCommand):
             self.searchoutput(out,
                               r'"ram" = list\(\s*'
                               r'create\("hardware/ram/generic",\s*'
-                              r'"size", 8192\s*\)\s*\);',
+                              r'"size", 8192\*MB\s*\)\s*\);',
                               command)
             self.searchoutput(out,
                               r'"cpu" = list\(\s*'
@@ -485,7 +485,7 @@ class TestAddVirtualHardware(EventsTestMixin, TestBrokerCommand):
                               r'"harddisks/\{sda\}" = nlist\(\s*'
                               r'"address", "0:0",\s*'
                               r'"boot", true,\s*'
-                              r'"capacity", 15\*1024,\s*'
+                              r'"capacity", 15\*GB,\s*'
                               r'"interface", "sata",\s*'
                               r'"mountpoint", "/vol/lnn30f1v1/%s",\s*'
                               r'"path", "%s/sda.vmdk",\s*'

--- a/tests/broker/test_del_disk.py
+++ b/tests/broker/test_del_disk.py
@@ -57,7 +57,7 @@ class TestDelDisk(EventsTestMixin, TestBrokerCommand):
                           r'create\("hardware/harddisk/generic/cciss",\s*'
                           r'"boot", true,\s*'
                           r'"bus", "pci:0000:01:00.0",\s*'
-                          r'"capacity", 34\*1024,\s*'
+                          r'"capacity", 34\*GB,\s*'
                           r'"interface", "cciss"\s*\)',
                           command)
 

--- a/tests/broker/test_update_disk.py
+++ b/tests/broker/test_update_disk.py
@@ -104,7 +104,7 @@ class TestUpdateDisk(EventsTestMixin, TestBrokerCommand):
                           r'create\("hardware/harddisk/generic/cciss",\s*'
                           r'"boot", true,\s*'
                           r'"bus", "pci:0000:01:00.0",\s*'
-                          r'"capacity", 34\*1024,\s*'
+                          r'"capacity", 34\*GB,\s*'
                           r'"interface", "cciss",\s*'
                           r'"wwn", "600508b112233445566778899aabbccd"\s*\);',
                           command)
@@ -113,7 +113,7 @@ class TestUpdateDisk(EventsTestMixin, TestBrokerCommand):
                           r'create\("hardware/harddisk/generic/sata",\s*'
                           r'"address", "0:0:0:0",\s*'
                           r'"bus", "pci:0000:02:00.0",\s*'
-                          r'"capacity", 50\*1024,\s*'
+                          r'"capacity", 50\*GB,\s*'
                           r'"interface", "sata"\s*\);',
                           command)
         self.matchclean(out, "c0d0", command)
@@ -167,7 +167,7 @@ class TestUpdateDisk(EventsTestMixin, TestBrokerCommand):
                           r'"harddisks/{sda}" = nlist\(\s*'
                           r'"address", "0:1",\s*'
                           r'"boot", true,\s*'
-                          r'"capacity", 45\*1024,\s*'
+                          r'"capacity", 45\*GB,\s*'
                           r'"filesystemname", "disk_update_test",\s*'
                           r'"interface", "scsi",\s*'
                           r'"iopslimit", 30,\s*'
@@ -211,7 +211,7 @@ class TestUpdateDisk(EventsTestMixin, TestBrokerCommand):
                           r'"harddisks/{sda}" = nlist\(\s*'
                           r'"address", "0:0",\s*'
                           r'"boot", true,\s*'
-                          r'"capacity", 45\*1024,\s*'
+                          r'"capacity", 45\*GB,\s*'
                           r'"interface", "scsi",\s*'
                           r'"iopslimit", 30,\s*'
                           r'"mountpoint", "/vol/lnn30f1v1/utecl5_share",\s*'
@@ -261,7 +261,7 @@ class TestUpdateDisk(EventsTestMixin, TestBrokerCommand):
                           r'"harddisks/{sdb}" = '
                           r'create\("hardware/harddisk/generic/scsi",\s*'
                           r'"address", "0:0:1:0",\s*'
-                          r'"capacity", 34\*1024,\s*'
+                          r'"capacity", 34\*GB,\s*'
                           r'"interface", "scsi",\s*'
                           r'"wwn", "600508b112233445566778899aabbccd"\s*\);',
                           command)

--- a/tests/broker/test_update_machine.py
+++ b/tests/broker/test_update_machine.py
@@ -58,7 +58,7 @@ class TestUpdateMachine(EventsTestMixin, TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 8192\s*\)\s*\);',
+                          r'"size", 8192\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
@@ -126,7 +126,7 @@ class TestUpdateMachine(EventsTestMixin, TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 8192\s*\)\s*\);',
+                          r'"size", 8192\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
@@ -180,7 +180,7 @@ class TestUpdateMachine(EventsTestMixin, TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 8192\s*\)\s*\);',
+                          r'"size", 8192\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
@@ -476,7 +476,7 @@ class TestUpdateMachine(EventsTestMixin, TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 12288\s*\)\s*\);',
+                          r'"size", 12288\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'

--- a/tests/broker/test_update_model.py
+++ b/tests/broker/test_update_model.py
@@ -34,13 +34,13 @@ class TestUpdateModel(TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 8192\s*\)\s*\);',
+                          r'"size", 8192\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
                           r'create\("hardware/cpu/intel/l5520"\)\s*\);',
                           command)
-        self.matchoutput(out, '"capacity", 15*1024,', command)
+        self.matchoutput(out, '"capacity", 15*GB,', command)
         self.matchoutput(out, '"interface", "sata",', command)
 
     def test_100_updateexisting(self):
@@ -74,13 +74,13 @@ class TestUpdateModel(TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 4096\s*\)\s*\);',
+                          r'"size", 4096\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
                           r'create\("hardware/cpu/intel/utcpu"\)\s*\);',
                           command)
-        self.matchoutput(out, '"capacity", 45*1024,', command)
+        self.matchoutput(out, '"capacity", 45*GB,', command)
         self.matchoutput(out, '"interface", "scsi",', command)
 
     def test_130_clear_comments(self):
@@ -122,13 +122,13 @@ class TestUpdateModel(TestBrokerCommand):
         self.searchoutput(out,
                           r'"ram" = list\(\s*'
                           r'create\("hardware/ram/generic",\s*'
-                          r'"size", 4096\s*\)\s*\);',
+                          r'"size", 4096\*MB\s*\)\s*\);',
                           command)
         self.searchoutput(out,
                           r'"cpu" = list\(\s*'
                           r'create\("hardware/cpu/intel/utcpu"\)\s*\);',
                           command)
-        self.matchoutput(out, '"capacity", 45*1024,', command)
+        self.matchoutput(out, '"capacity", 45*GB,', command)
         self.matchoutput(out, '"interface", "scsi",', command)
 
     def test_300_updatetype(self):

--- a/tests/unittest.conf
+++ b/tests/unittest.conf
@@ -123,7 +123,6 @@ default_domain = ut-prod
 
 [panc]
 pan_compiler = %(basedir)s/panc-links/panc-%(version)s.jar
-include_pan = True
 
 [site]
 # Site specific settings


### PR DESCRIPTION
For host, cluster and metacluster plenary templates, include a preface template, called `archetype/declarations.pan`, intended mainly to define the loadpath for the rest of the profile. This happens only if the broker config option `object_declarations_template` is `true` (`false` by default).

Broker option `include_pan` is also removed (addition reverted), as it is superseded by the previous change

**This PR is critical for enable the use of the template library in Aquilon**

Fixes #86
