### PR TITLE
Broker: pass archetype to the object profile

### DIFF
--- a/lib/aquilon/worker/templates/host.py
+++ b/lib/aquilon/worker/templates/host.py
@@ -233,6 +233,7 @@ class PlenaryHostData(StructurePlenary):
 
         lines.append("")
         dbos = self.dbobj.operating_system
+        pan_assign(lines, "system/archetype/name", self.dbobj.archetype.name)
         pan_assign(lines, "system/archetype/os", dbos.name)
         pan_assign(lines, "system/archetype/model", dbos.version)
         pan_assign(lines, "system/archetype/os_lifecycle", dbos.lifecycle)


### PR DESCRIPTION
This change allows the broker to pass the host archetype to the object profile as '/system/archetype/name`.

It includes an improvement of `pan_variable()` function to define a variable based on another variable, allow a construct like:

```pan
variable LOADPATH = list(ARCHETYPE);
```
This  `pan_variable()` change was originally made for an earlier version of this PR and is now no longer used but has been kept as it it potentially useful.

Fixes #88 
Contributes to #90 