### PR TITLE
Export archetype/os as a dict in hostdata template

### DIFF
--- a/etc/aqd.conf.defaults
+++ b/etc/aqd.conf.defaults
@@ -347,6 +347,9 @@ gzip_output = false
 transparent_gzip = true
 template_extension = .tpl
 include_pan = True
+# Define archetype/os as a dict (required by template library
+# since 17.7.0). Used to be a string.
+archetype_os_dict = False
 
 [tool_timeout]
 # If set to True, timeout will be set to 'default_value' for any tools run via subprocess

--- a/etc/aqd.conf.noms
+++ b/etc/aqd.conf.noms
@@ -83,6 +83,9 @@ location_uri_validator = /bin/true
 # The update_domain command expects to be able to read this value
 # in raw mode and set the version variable itself.
 pan_compiler = /usr/lib/panc.jar
+# Define archetype/os as a dict (required by template library
+# since 17.7.0). Used to be a string.
+archetype_os_dict = True
 
 ###############################################################################
 

--- a/lib/aquilon/worker/templates/host.py
+++ b/lib/aquilon/worker/templates/host.py
@@ -233,8 +233,12 @@ class PlenaryHostData(StructurePlenary):
 
         lines.append("")
         dbos = self.dbobj.operating_system
-        pan_assign(lines, "system/archetype/os", dbos.name)
-        pan_assign(lines, "system/archetype/model", dbos.version)
+        if self.config.getboolean("panc", "archetype_os_dict"):
+            pan_assign(lines, "system/archetype/os/name", dbos.name)
+            pan_assign(lines, "system/archetype/os/version", dbos.version)
+        else:
+            pan_assign(lines, "system/archetype/os", dbos.name)
+            pan_assign(lines, "system/archetype/model", dbos.version)
         pan_assign(lines, "system/archetype/os_lifecycle", dbos.lifecycle)
 
         lines.append("")


### PR DESCRIPTION
- Requires archetype_os_dict=true in aqd.conf (default: false)
- Required for template libary >= 17.7.0 support

Fixes #93

Change-Id: Ibfb52dc616209dfd892449e572f95499f4ee6737