### PR TITLE
Config file path: allow to ignore that an exe runs from the sources

### DIFF
--- a/bin/aq.py
+++ b/bin/aq.py
@@ -297,7 +297,8 @@ def get_default_opts(auth_option, conf_file=None):
     config = SafeConfigParser()
 
     if not conf_file:
-        conf_file = lookup_file_path("aq.conf")
+        # By default, always use the system-wide config file if present
+        conf_file = lookup_file_path("aq.conf", check_conf_in_sources=True)
 
     if conf_file:
         config.read(conf_file)

--- a/bin/aq.py
+++ b/bin/aq.py
@@ -298,7 +298,11 @@ def get_default_opts(auth_option, conf_file=None):
 
     if not conf_file:
         # By default, always use the system-wide config file if present
-        conf_file = lookup_file_path("aq.conf", check_conf_in_sources=True)
+        if globalOptions.get('develmode'):
+            check_conf_in_sources = False
+        else:
+            check_conf_in_sources = True
+        conf_file = lookup_file_path("aq.conf", check_conf_in_sources=check_conf_in_sources)
 
     if conf_file:
         config.read(conf_file)

--- a/etc/input.xml
+++ b/etc/input.xml
@@ -57,6 +57,9 @@
 		Pass a config file to client which indicates the broker to connect too.
 		Should default correctly, only useful for development.
 	    </option>
+		<option name="develmode" type="boolean">
+		Ignore the system-wide configuration file if present.
+		</option>
 	</optgroup>
     </command>
 

--- a/lib/aquilon/config.py
+++ b/lib/aquilon/config.py
@@ -48,15 +48,18 @@ def running_from_source():
     return os.path.exists(os.path.join(_SRCDIR, "Makefile"))
 
 
-def lookup_file_path(name):
+def lookup_file_path(name, check_conf_in_sources=False):
     """
     Return the full path of a data file.
 
-    If we're running from the source tree, then use the default files;
-    otherwise, use the system-wide ones.
+    If we're running from the source tree and check_conf_in_sources=True,
+    returns the source tree path only if the config file exists. Default
+    is to return it unconditionally.
     """
-    if running_from_source():
-        return os.path.join(_SRCDIR, "etc", name)
+    if  running_from_source():
+        source_config_path = os.path.join(_SRCDIR, "etc", name)
+        if os.path.exists(source_config_path) or not check_conf_in_sources:
+            return source_config_path
 
     paths_to_try = [os.path.join("/etc", "aquilon", name),
                     os.path.join("/usr", "share", "aquilon", "etc", name),


### PR DESCRIPTION
An attempt to address #98 by not returning inconditionally the source path when run from sources but checking that a config file exists in this path. This change affects potentially only `aq.py`: if there is no `aq.conf` in the source tree (the default), the system-wide config file will be used if it exists in one of the valid paths.

Fixes #98.