### PR TITLE
Generate "unique template" by default

### DIFF
--- a/lib/aquilon/worker/templates/base.py
+++ b/lib/aquilon/worker/templates/base.py
@@ -43,7 +43,7 @@ _mylocal = threading.local()
 
 
 class Plenary(object):
-    template_type = ""
+    template_type = "unique"
     """ Specifies the PAN template type to generate """
 
     handlers = {}


### PR DESCRIPTION
This PR changes the default template type from nothing to `unique`. It doesn't add the possibility to generate "non unique" templates as it seems unlikely that the broker may have to generate such a template (as an example, the template library contains very few such templates) and it would be easy to add another specific class for this (as for structure templates) if need be.

Contributes to #92

Change-Id: I152bab1c470594c47553f315bbc842e0e36e998d