### PR TITLE
machine plenary templates: allow to use the rack fullname

### DIFF
--- a/etc/aqd.conf.defaults
+++ b/etc/aqd.conf.defaults
@@ -353,6 +353,8 @@ gzip_output = false
 transparent_gzip = true
 template_extension = .tpl
 object_declarations_template = false
+# Use rack name in machine namespace
+machine_ns_rack_fullname = False
 
 [tool_timeout]
 # If set to True, timeout will be set to 'default_value' for any tools run via subprocess

--- a/etc/aqd.conf.noms
+++ b/etc/aqd.conf.noms
@@ -111,6 +111,9 @@ template_extension = .pan
 # Include a preface template in the object template if true
 object_declarations_template = true
 
+# Use rack fullname in machine namespace
+machine_ns_rack_fullname = True
+
 
 ###############################################################################
 

--- a/lib/aquilon/worker/templates/base.py
+++ b/lib/aquilon/worker/templates/base.py
@@ -628,7 +628,7 @@ class PlenaryCollection(object):
                 raise
 
 
-def add_location_info(lines, dblocation, prefix=""):
+def add_location_info(lines, dblocation, prefix="", use_rack_fullname=False):
     # FIXME: sort out hub/region
     for parent_type in ["continent", "country", "city", "campus", "building",
                         "bunker"]:
@@ -637,7 +637,11 @@ def add_location_info(lines, dblocation, prefix=""):
             pan_assign(lines, prefix + "sysloc/" + parent_type, dbparent.name)
 
     if dblocation.rack:
-        pan_assign(lines, prefix + "rack/name", dblocation.rack.name)
+        # If use_rack_fullname is True, use the rack_fullname instead of the generated rack name
+        if use_rack_fullname:
+            pan_assign(lines, prefix + "rack/name", dblocation.rack.fullname.lower())
+        else:
+            pan_assign(lines, prefix + "rack/name", dblocation.rack.name)
         if dblocation.rack_row:
             pan_assign(lines, prefix + "rack/row", dblocation.rack_row)
         if dblocation.rack_column:


### PR DESCRIPTION
- If config option machine_ns_rack_fullname is true (default is false
to maintain backward compatibility, use the rack fullname instead of
the rack name to build the machine namespace in the plenary templates.
- When the option is true, also export the rack fullname instead of
the rack name in /hardware/rack/name.

Fixes #105 (GitHub issue https://github.com/quattor/aquilon/issues/105)

Change-Id: I99dd2d0af0091dca588e576d45b18bd833100fbc