### PR TITLE
Change site and machine namespace to use continent name

### DIFF
--- a/lib/aquilon/worker/templates/base.py
+++ b/lib/aquilon/worker/templates/base.py
@@ -629,12 +629,16 @@ class PlenaryCollection(object):
 
 
 def add_location_info(lines, dblocation, prefix=""):
-    # FIXME: sort out hub/region
-    for parent_type in ["continent", "country", "city", "campus", "building",
-                        "bunker"]:
+    for parent_type in ["hub", "continent", "country", "city", "campus", "building",
+                        "room", "bunker"]:
         dbparent = getattr(dblocation, parent_type)
         if dbparent:
-            pan_assign(lines, prefix + "sysloc/" + parent_type, dbparent.name)
+            # Hub is an exception where the associated sysloc property has a different name
+            if parent_type == "hub":
+                sysloc_property = "region"
+            else:
+                sysloc_property = parent_type
+            pan_assign(lines, prefix + "sysloc/" + sysloc_property, dbparent.name)
 
     if dblocation.rack:
         pan_assign(lines, prefix + "rack/name", dblocation.rack.name)
@@ -642,5 +646,3 @@ def add_location_info(lines, dblocation, prefix=""):
             pan_assign(lines, prefix + "rack/row", dblocation.rack_row)
         if dblocation.rack_column:
             pan_assign(lines, prefix + "rack/column", dblocation.rack_column)
-    if dblocation.room:
-        pan_assign(lines, prefix + "sysloc/room", dblocation.room.name)

--- a/lib/aquilon/worker/templates/city.py
+++ b/lib/aquilon/worker/templates/city.py
@@ -30,7 +30,7 @@ class PlenaryCity(Plenary):
 
     @classmethod
     def template_name(cls, dbcity):
-        return "%s/%s/%s/config" % (cls.prefix, dbcity.hub.fullname.lower(),
+        return "%s/%s/%s/config" % (cls.prefix, dbcity.continent.name,
                                     dbcity.name)
 
     def body(self, lines):

--- a/lib/aquilon/worker/templates/machine.py
+++ b/lib/aquilon/worker/templates/machine.py
@@ -40,7 +40,7 @@ class PlenaryMachineInfo(StructurePlenary):
     @classmethod
     def template_name(cls, dbmachine):
         loc = dbmachine.location
-        return "%s/%s/%s/%s/%s" % (cls.prefix, loc.hub.fullname.lower(),
+        return "%s/%s/%s/%s/%s" % (cls.prefix, loc.continent.name,
                                    loc.building, loc.rack, dbmachine.label)
 
     def __init__(self, dbobj, **kwargs):


### PR DESCRIPTION
The hub fullname was used previously but as it was not exported to the object plenary, it was impossible to locate the site template (not included by default in the object plenary)
- It is recommended to flush machine and site firt and deploy them in all domains (old templates are not removed by the broker) before flushing hosts.
- Hosts must be flushed to use the new namespace

This PR also adds the hub information in the object plenary under `/hardware/sysloc/region`.

Fixes #104

Change-Id: I71e59ffa750a264b88ecf35ae3e6ebecd73f98e2