### PR TITLE
Relaxed feature template checks in bind feature and manage commands

### DIFF
--- a/etc/aqd.conf.defaults
+++ b/etc/aqd.conf.defaults
@@ -350,6 +350,9 @@ gzip_output = false
 transparent_gzip = true
 template_extension = .tpl
 object_declarations_template = false
+# When true, only display a warning if a feature template doesn't
+# exist in a domain Git repository
+relaxed_feature_template_check = False
 
 [tool_timeout]
 # If set to True, timeout will be set to 'default_value' for any tools run via subprocess

--- a/lib/aquilon/worker/commands/bind_feature.py
+++ b/lib/aquilon/worker/commands/bind_feature.py
@@ -141,7 +141,7 @@ class CommandBindFeature(BrokerCommand):
         q = q.filter(or_(*filters))
 
         for dbdomain in q:
-            check_feature_template(self.config, dbarchetype, dbfeature,
+            check_feature_template(self.config, logger, dbarchetype, dbfeature,
                                    dbdomain)
 
         add_link(session, logger, dbfeature, params)

--- a/lib/aquilon/worker/commands/manage_list.py
+++ b/lib/aquilon/worker/commands/manage_list.py
@@ -181,7 +181,7 @@ class CommandManageList(BrokerCommand):
 
                 for dbarch, featureset in features.items():
                     for dbfeature in featureset:
-                        check_feature_template(self.config, dbarch, dbfeature,
+                        check_feature_template(self.config, logger, dbarch, dbfeature,
                                                dbbranch)
 
         for dbobj in objects:

--- a/lib/aquilon/worker/dbwrappers/feature.py
+++ b/lib/aquilon/worker/dbwrappers/feature.py
@@ -61,13 +61,17 @@ def add_link(session, logger, dbfeature, params):
 
 def check_feature_template(config, dbarchetype, dbfeature, dbdomain):
     basedir = template_branch_basedir(config, dbdomain)
+    # Features can be defined either in the archetype directory or as
+    # features shared by all the archetypes if they are defined in basedir
+    feature_template_dirs = ['{}/{}/{}'.format(basedir, dbarchetype.name, dbfeature.cfg_path),
+                             '{}/{}'.format(basedir, dbfeature.cfg_path)]
 
     # The broker has no control over the extension used, so we check for
     # everything panc accepts
     for ext in ('pan', 'tpl'):
-        if os.path.exists("%s/%s/%s/config.%s" % (basedir, dbarchetype.name,
-                                                  dbfeature.cfg_path, ext)):
-            return
+        for feature_dir in feature_template_dirs:
+            if os.path.exists("{}/config.{}" .format(feature_dir, ext)):
+                return
 
         # Legacy path for hardware features
         if os.path.exists("%s/%s/%s.%s" % (basedir, dbarchetype.name,

--- a/lib/aquilon/worker/dbwrappers/feature.py
+++ b/lib/aquilon/worker/dbwrappers/feature.py
@@ -27,7 +27,6 @@ from aquilon.aqdb.model import (FeatureLink, Personality, PersonalityStage,
 from aquilon.worker.templates import PlenaryHost, PlenaryPersonality
 from aquilon.worker.templates.domain import template_branch_basedir
 
-
 def add_link(session, logger, dbfeature, params):
     FeatureLink.get_unique(session, feature=dbfeature, preclude=True,
                            **params)
@@ -59,7 +58,7 @@ def add_link(session, logger, dbfeature, params):
     dbfeature.links.append(FeatureLink(**params))
 
 
-def check_feature_template(config, dbarchetype, dbfeature, dbdomain):
+def check_feature_template(config, logger, dbarchetype, dbfeature, dbdomain):
     basedir = template_branch_basedir(config, dbdomain)
     # Features can be defined either in the archetype directory or as
     # features shared by all the archetypes if they are defined in basedir
@@ -73,8 +72,12 @@ def check_feature_template(config, dbarchetype, dbfeature, dbdomain):
             if os.path.exists("{}/config.{}" .format(feature_dir, ext)):
                 return
 
-    raise ArgumentError("{0} does not have templates present in {1:l} "
-                        "for {2:l}.".format(dbfeature, dbdomain, dbarchetype))
+    if config.getboolean("panc", "relaxed_feature_template_check"):
+        logger.client_info("WARNING: {0} templates not present in {1:l} for {2:l} "
+                           "(assumed to be present in plenary templates).".format(dbfeature, dbdomain, dbarchetype))
+    else:
+        raise ArgumentError("{0} does not have templates present in {1:l} "
+                            "for {2:l}.".format(dbfeature, dbdomain, dbarchetype))
 
 
 def get_affected_plenaries(session, dbfeature, plenaries,

--- a/lib/aquilon/worker/dbwrappers/feature.py
+++ b/lib/aquilon/worker/dbwrappers/feature.py
@@ -68,15 +68,10 @@ def check_feature_template(config, dbarchetype, dbfeature, dbdomain):
 
     # The broker has no control over the extension used, so we check for
     # everything panc accepts
-    for ext in ('pan', 'tpl'):
-        for feature_dir in feature_template_dirs:
+    for feature_dir in feature_template_dirs:
+        for ext in ('pan', 'tpl'):
             if os.path.exists("{}/config.{}" .format(feature_dir, ext)):
                 return
-
-        # Legacy path for hardware features
-        if os.path.exists("%s/%s/%s.%s" % (basedir, dbarchetype.name,
-                                           dbfeature.cfg_path, ext)):
-            return
 
     raise ArgumentError("{0} does not have templates present in {1:l} "
                         "for {2:l}.".format(dbfeature, dbdomain, dbarchetype))

--- a/lib/aquilon/worker/dbwrappers/host.py
+++ b/lib/aquilon/worker/dbwrappers/host.py
@@ -84,7 +84,7 @@ def create_host(session, logger, config, dbhw, dbarchetype, domain=None,
         pre, post = host_features(dbstage)
         hw_features = hardware_features(dbstage, dbhw.model)
         for dbfeature in pre | post | hw_features:
-            check_feature_template(config, dbarchetype, dbfeature, dbbranch)
+            check_feature_template(config, logger, dbarchetype, dbfeature, dbbranch)
 
     if not osname:
         if config.has_option(section, "default_osname"):


### PR DESCRIPTION
This PR addresses issue #111 by:
* Looking for feature templates in the root directory of the domain Git repo, in addition to the archetype directory.
* Enabling a relaxed feature template check when config option `relaxed_feature_template_check` is true (false by default) where a warning is displayed if the template existence is assessed rather than raising an exception. This allows to support direct use of template library features.

Not done yet:
* Removed check in `aq manage` if `--skip_auto_complle` is not present: not clear what the added value would be as it will not help much is you don't have `relaxed_feature_template_check=True` and will only remove the warning if you have it.
* Option to enforce that only one feature template must exist in the domain Git repo, whatever the location. Waiting for feedback on whether it is needed or not.

Successfully tested at LAL.