### PR TITLE
aq pxeswitch: allow to configure aii-installfe cdburl

### DIFF
--- a/etc/aqd.conf.defaults
+++ b/etc/aqd.conf.defaults
@@ -155,6 +155,9 @@ plenarydir = %(cfgdir)s/plenary
 service = %(user)s
 keytab = /var/spool/keytabs/%(service)s
 installfe_user = %(user)s
+# Define installfe_cdburl to the URL used to serve broker profiles
+# if you want Aquilon to manage AII cdburl
+installfe_cdburl =
 server_notifications =
 client_notifications = yes
 sharedata = /ms/dist/storage/etc/nasobjects.cdb

--- a/lib/aquilon/worker/commands/pxeswitch_list.py
+++ b/lib/aquilon/worker/commands/pxeswitch_list.py
@@ -63,6 +63,9 @@ class CommandPXESwitchList(BrokerCommand):
         args.append("--logfile")
         logdir = self.config.get("broker", "logdir")
         args.append("%s/aii-installfe.log" % logdir)
+        # If installfe_cdburl option is defined, pass it to aii-installfe/shellfe
+        if self.config.has_value("broker", "installfe_cdburl"):
+            args.extend(['--cdburl', self.config.get("broker", "installfe_cdburl")])
 
         dbservice = Service.get_unique(session, "bootserver", compel=True)
         dbhosts = hostlist_to_hosts(session, list)


### PR DESCRIPTION
This helps with sharing an AII server between several sources, in particular between SCDB and Aquilon.

Fixes #113 (https://github.com/quattor/aquilon/issues/113)

Requires https://github.com/quattor/aii/pull/291 (`aii-installfe` counterpart) to be useful.