### PR TITLE
services: insert service data early in the object template

### DIFF
--- a/lib/aquilon/worker/commands/cat_instance.py
+++ b/lib/aquilon/worker/commands/cat_instance.py
@@ -18,7 +18,7 @@
 
 from aquilon.aqdb.model import Service, ServiceInstance
 from aquilon.worker.broker import BrokerCommand
-from aquilon.worker.templates.service import (PlenaryServiceInstanceToplevel,
+from aquilon.worker.templates.service import (PlenaryServiceInstanceData,
                                               PlenaryServiceInstanceClientDefault,
                                               PlenaryServiceInstanceServer,
                                               PlenaryServiceInstanceServerDefault)
@@ -45,7 +45,7 @@ class CommandCatInstance(BrokerCommand):
             if server:
                 cls = PlenaryServiceInstanceServer
             else:
-                cls = PlenaryServiceInstanceToplevel
+                cls = PlenaryServiceInstanceData
 
         plenary_info = cls.get_plenary(dbsi, logger=logger)
 

--- a/lib/aquilon/worker/commands/cat_service.py
+++ b/lib/aquilon/worker/commands/cat_service.py
@@ -18,7 +18,7 @@
 
 from aquilon.aqdb.model import Service
 from aquilon.worker.broker import BrokerCommand
-from aquilon.worker.templates.service import (PlenaryServiceToplevel,
+from aquilon.worker.templates.service import (PlenaryServiceData,
                                               PlenaryServiceClientDefault,
                                               PlenaryServiceServerDefault)
 
@@ -38,7 +38,7 @@ class CommandCatService(BrokerCommand):
             else:
                 cls = PlenaryServiceClientDefault
         else:
-            cls = PlenaryServiceToplevel
+            cls = PlenaryServiceData
 
         plenary_info = cls.get_plenary(dbservice, logger=logger)
 

--- a/lib/aquilon/worker/commands/update_machine.py
+++ b/lib/aquilon/worker/commands/update_machine.py
@@ -29,7 +29,7 @@ from aquilon.worker.dbwrappers.location import get_location
 from aquilon.worker.dbwrappers.resources import (find_resource,
                                                  get_resource_holder)
 from aquilon.worker.templates import (PlenaryHostData,
-                                      PlenaryServiceInstanceToplevel)
+                                      PlenaryServiceInstanceData)
 from aquilon.worker.processes import DSDBRunner
 from aquilon.worker.dbwrappers.change_management import ChangeManagement
 
@@ -325,7 +325,7 @@ class CommandUpdateMachine(BrokerCommand):
             if dbmachine.host:
                 for srv in dbmachine.host.services_provided:
                     si = srv.service_instance
-                    plenaries.add(si, cls=PlenaryServiceInstanceToplevel)
+                    plenaries.add(si, cls=PlenaryServiceInstanceData)
             update_primary_ip(session, logger, dbmachine, ip)
 
         if dbmachine.location != old_location and dbmachine.host:

--- a/lib/aquilon/worker/templates/__init__.py
+++ b/lib/aquilon/worker/templates/__init__.py
@@ -26,11 +26,11 @@ from aquilon.worker.templates.machine import PlenaryMachineInfo
 from aquilon.worker.templates.network import PlenaryNetwork
 from aquilon.worker.templates.resource import PlenaryResource
 from aquilon.worker.templates.service import (PlenaryService,
-                                              PlenaryServiceToplevel,
+                                              PlenaryServiceData,
                                               PlenaryServiceClientDefault,
                                               PlenaryServiceServerDefault,
                                               PlenaryServiceInstance,
-                                              PlenaryServiceInstanceToplevel,
+                                              PlenaryServiceInstanceData,
                                               PlenaryServiceInstanceClientDefault,
                                               PlenaryServiceInstanceServer,
                                               PlenaryServiceInstanceServerDefault)

--- a/lib/aquilon/worker/templates/service.py
+++ b/lib/aquilon/worker/templates/service.py
@@ -37,8 +37,8 @@ class PlenaryService(PlenaryCollection):
         super(PlenaryService, self).__init__(logger=logger,
                                              allow_incomplete=allow_incomplete)
 
-        self.append(PlenaryServiceToplevel.get_plenary(dbservice,
-                                                       allow_incomplete=allow_incomplete))
+        self.append(PlenaryServiceData.get_plenary(dbservice,
+                                                   allow_incomplete=allow_incomplete))
         self.append(PlenaryServiceClientDefault.get_plenary(dbservice,
                                                             allow_incomplete=allow_incomplete))
         self.append(PlenaryServiceServerDefault.get_plenary(dbservice,
@@ -48,7 +48,7 @@ class PlenaryService(PlenaryCollection):
 Plenary.handlers[Service] = PlenaryService
 
 
-class PlenaryServiceToplevel(StructurePlenary):
+class PlenaryServiceData(StructurePlenary):
     """
     The top-level service template does nothing. It is really
     a placeholder which can be overridden by the library
@@ -128,8 +128,8 @@ class PlenaryServiceInstance(SIHelperMixin, PlenaryCollection):
                                                      allow_incomplete=allow_incomplete)
         self.dbobj = dbinstance
 
-        self.append(PlenaryServiceInstanceToplevel.get_plenary(dbinstance,
-                                                               allow_incomplete=allow_incomplete))
+        self.append(PlenaryServiceInstanceData.get_plenary(dbinstance,
+                                                           allow_incomplete=allow_incomplete))
         self.append(PlenaryServiceInstanceClientDefault.get_plenary(dbinstance,
                                                                     allow_incomplete=allow_incomplete))
         self.append(PlenaryServiceInstanceServer.get_plenary(dbinstance,
@@ -140,7 +140,7 @@ class PlenaryServiceInstance(SIHelperMixin, PlenaryCollection):
 Plenary.handlers[ServiceInstance] = PlenaryServiceInstance
 
 
-class PlenaryServiceInstanceToplevel(SIHelperMixin, StructurePlenary):
+class PlenaryServiceInstanceData(SIHelperMixin, StructurePlenary):
     """
     This structure template provides information for the template
     specific to the service instance and for use by the client.
@@ -159,7 +159,7 @@ class PlenaryServiceInstanceToplevel(SIHelperMixin, StructurePlenary):
 
     def body(self, lines):
         pan_include(lines,
-                    PlenaryServiceToplevel.template_name(self.dbobj.service))
+                    PlenaryServiceData.template_name(self.dbobj.service))
         lines.append("")
         pan_assign(lines, "instance", self.dbobj.name)
 
@@ -201,8 +201,9 @@ class PlenaryServiceInstanceClientDefault(SIHelperMixin, Plenary):
     included from within the host.tpl. This may
     be overridden within the template library, but this plenary
     should typically be sufficient without override.
-    This template defines configuration for clients only, and
-    is specific to the instance.
+    This template defines configuration specific to the instance
+    for clients only but the instance data has to be loaded before
+    (the broker does it earlier in host object template).
     """
 
     prefix = "service"
@@ -213,10 +214,6 @@ class PlenaryServiceInstanceClientDefault(SIHelperMixin, Plenary):
                                            dbinstance.name)
 
     def body(self, lines):
-        path = PlenaryServiceInstanceToplevel.template_name(self.dbobj)
-        pan_assign(lines, "/system/services/%s" % self.dbobj.service,
-                   StructureTemplate(path))
-
         path = PlenaryServiceClientDefault.template_name(self.dbobj.service)
         pan_include(lines, path)
 


### PR DESCRIPTION
This change allows service data to be available early in the object
template, before archetype/base is included. This makes possible to use
the service data for configuring any aspect of the host, cluster or
metacluster.

- Includes a renaming of PlenaryServicexxxTopLevel classes into
PlenaryServicexxxData

Fixes #109 (https://github.com/quattor/aquilon/issues/109)

Host part has been tested at LAL but not the cluster/metacluster as we don't have such object for the moment and as I have no clue on how to run the unit tests.