### PR TITLE
Correct syntax errors in database upgrade to 1.15.0

### DIFF
--- a/upgrade/1.15.0/30_hostlinks_parents.psql
+++ b/upgrade/1.15.0/30_hostlinks_parents.psql
@@ -1,4 +1,4 @@
-ALTER TABLE hostlink ALTER target SET NULL;
+ALTER TABLE hostlink ALTER COLUMN target DROP NOT NULL;
 
 CREATE TABLE hostlink_parent_map (
         resource_id INTEGER NOT NULL,

--- a/upgrade/1.15.0/70_hostlinks_parents.psql.backout
+++ b/upgrade/1.15.0/70_hostlinks_parents.psql.backout
@@ -1,3 +1,3 @@
-ALTER TABLE hostlink ALTER target SET NOT NULL;
+ALTER TABLE hostlink ALTER COLUMN target SET NOT NULL;
 
 DROP TABLE IF EXISTS hostlink_parent_map;


### PR DESCRIPTION
Corrects the syntax errors that occur when removing (upgrade) or restoring (backout) the "NOT NULL" constraint on the "target" column in the "hostlink" table for the postgresql DBMS. From a quick consultation with Dr. Google, the Oracle DBMS syntax appears to be correct.

This addresses issue issue #131

Change-Id: I86c5a8d4d09c5becfc545b2dcb557e831d30c275