### PR TITLE
Fix the systemd unit file for the broker

### DIFF
--- a/etc/systemd/aquilon-broker.service
+++ b/etc/systemd/aquilon-broker.service
@@ -7,7 +7,7 @@ After=network.target
 EnvironmentFile=/etc/sysconfig/aqd
 # Update python path to reflect your configuration. If a virtualenv is used, be sure to use the python path
 # for the virutalenv
-ExecStart=/usr/bin/python ${TWISTD} --logfile=${LOGFILE} --pidfile=${PIDFILE} aqd --config=${CONF_FILE}"
+ExecStart=/usr/bin/python ${TWISTD} --logfile=${LOGFILE} --pidfile=${PIDFILE} aqd --config=${CONF_FILE}
 Restart=always
 SyslogIdentifier=aqd
 User=aquilon


### PR DESCRIPTION
This change removes the double-quotation character at the end of the ExecStart line as this breaks the unit file for use by systemd.

This change address issue #133

Change-Id: If8c020bf339da298a5e08a9826f39f3e98c92c19